### PR TITLE
Milestone 5: fix asset paths for PyInstaller build

### DIFF
--- a/CODE/MoonRock.py
+++ b/CODE/MoonRock.py
@@ -21,8 +21,17 @@ import sys
 from pathlib import Path
 import random  # used for random enemy spawn positions
 
-BASE_DIR = Path(__file__).resolve().parent.parent  # .../moonrock
-ASSETS_DIR = BASE_DIR / 'Assets'                   # .../moonrock/Assets
+def resource_path(relative_path: str) -> Path:
+    '''
+    Docstring for resource_path
+    Get absolute path to resource, works for dev and for PyInstaller EXE.
+    '''
+    if hasattr(sys, "_MEIPASS"):
+        # PyInstaller extracts files to a temporary folder stored in sys._MEIPASS
+        return Path(sys._MEIPASS) / relative_path
+    return Path(__file__).resolve().parent.parent / relative_path
+
+ASSETS_DIR = resource_path("Assets")   # points to ./Assets in dev, or bundled Assets in EXE
 
 pygame.init()
 pygame.font.init()


### PR DESCRIPTION
Purpose:
- Ensure Assets are found both in development and in the PyInstaller EXE.

Changes:
- Added resource_path() helper (supports sys._MEIPASS).
- Updated ASSETS_DIR to use resource_path("Assets").

Milestone:
- Meilenstein 5 (ZIP: sofort ausführbar)